### PR TITLE
Prevent policy on parameters with JSON object values

### DIFF
--- a/src/main/java/se/swedenconnect/oidcfed/commons/configuration/PolicyParameterFormats.java
+++ b/src/main/java/se/swedenconnect/oidcfed/commons/configuration/PolicyParameterFormats.java
@@ -43,6 +43,11 @@ public enum PolicyParameterFormats {
   introspection_endpoint_auth_signing_alg_values_supported(null, ValueType.STRING_ARRAY),
   code_challenge_methods_supported(null, ValueType.STRING_ARRAY),
 
+  // OpenID Federation metadata
+  client_registration_types_supported(null, ValueType.STRING_ARRAY),
+  federation_registration_endpoint(null, ValueType.STRING),
+  request_authentication_methods_supported(null, ValueType.OBJECT),
+  request_authentication_signing_alg_values_supported(null, ValueType.STRING_ARRAY),
   // Additional Op metadata
   userinfo_endpoint(null, ValueType.STRING),
   acr_values_supported(null, ValueType.STRING_ARRAY),

--- a/src/main/java/se/swedenconnect/oidcfed/commons/configuration/ValueType.java
+++ b/src/main/java/se/swedenconnect/oidcfed/commons/configuration/ValueType.java
@@ -13,4 +13,6 @@ public class ValueType {
 
   public static final String BOOLEAN_ARRAY = "boolean_array";
 
+  public static final String OBJECT = "object";
+
 }

--- a/src/main/java/se/swedenconnect/oidcfed/commons/data/metadata/OpMetadata.java
+++ b/src/main/java/se/swedenconnect/oidcfed/commons/data/metadata/OpMetadata.java
@@ -23,6 +23,46 @@ public class OpMetadata extends BasicASMetadata {
     new OidcLangJsonSerializer<>(OpMetadata.class);
 
   /**
+   * OpenID Federation
+   * REQUIRED. Array specifying the federation types supported. Federation-type values defined by this specification are automatic and
+   * explicit. Additional values MAY be defined and used, without restriction by this specification.
+   */
+  @JsonProperty("client_registration_types_supported")
+  @Getter @Setter private List<List> clientRegistrationTypesSupported;
+
+  /**
+   * OpenID Federation
+   * OPTIONAL. URL of the OP's federation-specific Dynamic Client Registration Endpoint. If the OP supports Explicit Client Registration
+   * Endpoint this URL MUST use the https scheme and MAY contain port, path, and query parameter components. If the OP supports Explicit
+   * Client Registration as described in Section 12.2, then this claim is REQUIRED.
+   */
+  @JsonProperty("federation_registration_endpoint")
+  @Getter @Setter private String federationRegistrationEndpoint;
+
+  /**
+   * OpenID Federation
+   * OPTIONAL.The request_authentication_methods_supported value is a JSON object where the member names are names of endpoints where the request
+   * authentication occurs. This MAY be either at the OP's Authorization Endpoint or the OP's Pushed Authorization Request (PAR) endpoint.
+   * Supported endpoint identifiers are authorization_endpoint and pushed_authorization_request_endpoint.
+   * The values of the JSON object members for the endpoint names are JSON arrays containing the names of the request authentication methods
+   * used at those endpoints.
+   * Valid values are private_key_jwt, tls_client_auth, self_signed_tls_client_auth, request_object.
+   * Other values may be used.
+   */
+  @JsonProperty("request_authentication_methods_supported")
+  @Getter @Setter private Map<String, List<String>> requestAuthenticationMethodsSupported;
+
+  /**
+   * OpenID Federation
+   * OPTIONAL. JSON array containing a list of the supported JWS [RFC7515] algorithms (alg values) for signing the JWT [RFC7519] used in
+   * the Request Object contained in the request parameter of an authorization request or in the private_key_jwt of a pushed authorization
+   * request. This entry MUST be present if either of these authentication methods are specified in the
+   * request_authentication_methods_supported entry.
+   */
+  @JsonProperty("request_authentication_signing_alg_values_supported")
+  @Getter @Setter private List<String> requestAuthenticationSigningAlgValuesSupported;
+
+  /**
    * RECOMMENDED. URL of the OP's UserInfo Endpoint [OpenID.Core]. This URL MUST use the https scheme and MAY contain
    * port, path, and query parameter components.
    */

--- a/src/main/java/se/swedenconnect/oidcfed/commons/data/metadata/policy/MetadataParameterPolicy.java
+++ b/src/main/java/se/swedenconnect/oidcfed/commons/data/metadata/policy/MetadataParameterPolicy.java
@@ -10,6 +10,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import se.swedenconnect.oidcfed.commons.configuration.MetadataParameter;
+import se.swedenconnect.oidcfed.commons.configuration.ValueType;
 import se.swedenconnect.oidcfed.commons.process.metadata.PolicyMergeException;
 import se.swedenconnect.oidcfed.commons.process.metadata.PolicyOperatorFactory;
 import se.swedenconnect.oidcfed.commons.process.metadata.PolicyProcessingException;
@@ -65,7 +66,10 @@ public class MetadataParameterPolicy {
     return builder.build();
   }
 
-  public static MetadataParameterPolicyBuilder builder(MetadataParameter parameter) {
+  public static MetadataParameterPolicyBuilder builder(MetadataParameter parameter) throws PolicyTranslationException {
+    if (parameter.getValueType().equals(ValueType.OBJECT)) {
+      throw new PolicyTranslationException("Metadata policy is not allowed for metadata parameters holding JSON objects");
+    }
     return new MetadataParameterPolicyBuilder(parameter);
   }
 

--- a/src/main/java/se/swedenconnect/oidcfed/commons/process/metadata/impl/StandardMetadataPolicySerializer.java
+++ b/src/main/java/se/swedenconnect/oidcfed/commons/process/metadata/impl/StandardMetadataPolicySerializer.java
@@ -9,6 +9,7 @@ import org.springframework.lang.NonNull;
 
 import lombok.RequiredArgsConstructor;
 import se.swedenconnect.oidcfed.commons.configuration.MetadataParameter;
+import se.swedenconnect.oidcfed.commons.configuration.ValueType;
 import se.swedenconnect.oidcfed.commons.data.metadata.policy.MetadataParameterPolicy;
 import se.swedenconnect.oidcfed.commons.data.metadata.policy.EntityTypeMetadataPolicy;
 import se.swedenconnect.oidcfed.commons.process.metadata.MetadataPolicySerializer;
@@ -29,6 +30,7 @@ import se.swedenconnect.oidcfed.commons.process.metadata.policyoperators.PolicyO
  * If this is the case, then these Entity types must use different instances if this class adapted to their
  * metadata parameters and value types.
  * </p>
+ * 
  */
 @RequiredArgsConstructor
 public class StandardMetadataPolicySerializer implements MetadataPolicySerializer {
@@ -63,6 +65,9 @@ public class StandardMetadataPolicySerializer implements MetadataPolicySerialize
         throw new PolicyProcessingException("Unsupported metadata parameter: " + metadataParameterName);
       }
       MetadataParameter metadataParameter = supportedMetadataParametersMap.get(metadataParameterName);
+      if (metadataParameter.getValueType().equals(ValueType.OBJECT)) {
+        throw new PolicyProcessingException("Metadata policy is not allowed for metadata parameters that contains a JSON object value");
+      }
       MetadataParameterPolicy.MetadataParameterPolicyBuilder parameterPolicyBuilder = MetadataParameterPolicy.builder(
         metadataParameter);
       Object parameterObj = jsonObject.get(metadataParameterName);


### PR DESCRIPTION
Updated MetadataParameterPolicy and StandardMetadataPolicySerializer to throw exceptions when JSON object values are encountered in metadata parameters. Added new OpenID Federation metadata parameters and defined a new ValueType for JSON objects. Enhanced OpMetadata with properties supporting OpenID Federation requirements.