### PR TITLE
Generalised metadata handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>se.oidc.oidfed</groupId>
   <artifactId>openid-federation-base</artifactId>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>2.0.1</version>
   <packaging>jar</packaging>
 
   <name>OIDC Sweden :: OpenID Federation :: Base</name>

--- a/src/main/java/se/oidc/oidfed/base/data/federation/EntityMetadataInfoClaim.java
+++ b/src/main/java/se/oidc/oidfed/base/data/federation/EntityMetadataInfoClaim.java
@@ -51,6 +51,9 @@ public class EntityMetadataInfoClaim {
 
   protected Map<String, Map<String, Object>> claimObjects;
 
+  /**
+   * Constructor for the EntityMetadataInfoClaim class.
+   */
   protected EntityMetadataInfoClaim() {
     claimObjects = new HashMap<>();
   }
@@ -58,67 +61,148 @@ public class EntityMetadataInfoClaim {
   /*
    * Backwards compatible getters and setters for common metadata types;
    */
+
+  /**
+   * Retrieves the OIDC Relying Party metadata object.
+   *
+   * @return Relying Party metadata JSON object map
+   */
   public Map<String, Object> getOidcRelyingPartyMetadataObject() {
     return claimObjects.get(OPENID_RELYING_PARTY);
   }
 
+  /**
+   * Sets the OIDC relying party metadata object.
+   *
+   * @param oidcRelyingPartyMetadata a JSON object map representing the OIDC relying party metadata
+   */
   public void setOidcRelyingPartyMetadataObject(Map<String, Object> oidcRelyingPartyMetadata){
     this.claimObjects.put(OPENID_RELYING_PARTY, oidcRelyingPartyMetadata);
 
   }
 
+  /**
+   * Retrieves the OpenID Connect Provider metadata as a JSON object map.
+   *
+   * @return OpenID Provider metadata JSON object map
+   */
   public Map<String, Object> getOpMetadataObject(){
     return claimObjects.get(OPENID_PROVIDER);
   }
 
+  /**
+   * Sets the OpenID Connect metadata object for the specific OpenID Provider.
+   *
+   * @param opMetadata a JSON object map representing the OpenID Provider metadata
+   */
   public void setOpMetadataObject(Map<String, Object> opMetadata){
     this.claimObjects.put(OPENID_PROVIDER, opMetadata);
   }
 
+  /**
+   * Retrieves the authorization server metadata JSON object map.
+   *
+   * @return authorization server metadata JSON object map.
+   */
   public Map<String, Object> getAuthorizationServerMetadataObject(){
     return claimObjects.get(OAUTH_AUTHORIZATION_SERVER);
   }
 
+  /**
+   * Sets the authorization server metadata JSON object map.
+   *
+   * @param authorizationServerMetadata authorization server metadata JSON object map
+   */
   public void setAuthorizationServerMetadataObject(Map<String, Object> authorizationServerMetadata){
     this.claimObjects.put(OAUTH_AUTHORIZATION_SERVER, authorizationServerMetadata);
   }
 
+  /**
+   * Retrieves the OAuth client metadata JSON object map.
+   *
+   * @return OAuth client metadata JSON object map
+   */
   public Map<String, Object> getOauthClientMetadataObject(){
     return claimObjects.get(OAUTH_CLIENT);
   }
 
+  /**
+   * Sets the OAuth client metadata JSON object map.
+   *
+   * @param oauthClientMetadata OAuth client metadata JSON object map
+   */
   public void setOauthClientMetadataObject(Map<String, Object> oauthClientMetadata){
     this.claimObjects.put(OAUTH_CLIENT, oauthClientMetadata);
   }
 
+  /**
+   * Retrieves the OAuth resource metadata JSON object map.
+   *
+   * @return OAuth resource metadata JSON object map
+   */
   public Map<String, Object> getOauthResourceMetadataObject(){
     return claimObjects.get(OAUTH_RESOURCE);
   }
 
+  /**
+   * Set the OAuth resource metadata JSON object map.
+   *
+   * @param oauthResourceMetadata OAuth resource metadata JSON object map
+   */
   public void setOauthResourceMetadataObject(Map<String, Object> oauthResourceMetadata){
     this.claimObjects.put(OAUTH_RESOURCE, oauthResourceMetadata);
   }
 
+  /**
+   * Retrieves the metadata JSON object map for the federation entity.
+   *
+   * @return federation entity JSON object map
+   */
   public Map<String, Object> getFederationEntityMetadataObject(){
     return claimObjects.get(FEDERATION_ENTITY);
   }
 
+  /**
+   * Sets the metadata JSON object map for the federation entity.
+   *
+   * @param federationEntityMetadata federation entity JSON object map
+   */
   public void setFederationEntityMetadataObject(Map<String, Object> federationEntityMetadata){
     this.claimObjects.put(FEDERATION_ENTITY, federationEntityMetadata);
   }
 
+  /**
+   * Retrieves the metadata JSON object map for the specified metadata type.
+   *
+   * @param metadataTypeName the type of metadata for which to retrieve the JSON object map
+   * @return a JSON object map representing the metadata object, or null if the specified type is not found.
+   */
   public Map<String, Object> getMetadataClaimsObject(String metadataTypeName) {
     return claimObjects.get(metadataTypeName);
   }
 
+  /**
+   * Sets the metadata claims object for the specified metadata type.
+   *
+   * @param metadataTypeName the type of metadata for which to set the JSON object map
+   * @param metadataClaims a JSON object map representing the metadata claims
+   */
   public void setMetadataClaimsObject(String metadataTypeName, Map<String, Object> metadataClaims) {
     this.claimObjects.put(metadataTypeName, metadataClaims);
   }
 
+  /**
+   * Constructs a new EntityMetadataInfoClaimBuilder for building a {@link EntityMetadataInfoClaim}.
+   *
+   * @return a new instance of EntityMetadataInfoClaimBuilder
+   */
   public static EntityMetadataInfoClaimBuilder builder() {
     return new EntityMetadataInfoClaimBuilder();
   }
 
+  /**
+   * A builder class for constructing an EntityMetadataInfoClaim object with various metadata objects.
+   */
   public static class EntityMetadataInfoClaimBuilder {
 
     private final EntityMetadataInfoClaim entityMetadataInfoClaim;
@@ -127,55 +211,115 @@ public class EntityMetadataInfoClaim {
       this.entityMetadataInfoClaim = new EntityMetadataInfoClaim();
     }
 
+    /**
+     * Set the OIDC relying party metadata object.
+     *
+     * @param oidcRelyingPartyMetadataObject a JSON object map representing the OIDC relying party metadata
+     * @return EntityMetadataInfoClaimBuilder instance for method chaining
+     */
     public EntityMetadataInfoClaimBuilder oidcRelyingPartyMetadataObject(
         final Map<String, Object> oidcRelyingPartyMetadataObject) {
       this.entityMetadataInfoClaim.setOidcRelyingPartyMetadataObject(oidcRelyingPartyMetadataObject);
       return this;
     }
 
+    /**
+     * Sets the OpenID Connect metadata object for the specific OpenID Provider.
+     *
+     * @param opMetadataObject a JSON object map representing the OpenID Provider metadata
+     * @return EntityMetadataInfoClaimBuilder instance for method chaining
+     */
     public EntityMetadataInfoClaimBuilder opMetadataObject(final Map<String, Object> opMetadataObject) {
       this.entityMetadataInfoClaim.setOpMetadataObject(opMetadataObject);
       return this;
     }
 
+    /**
+     * Sets the authorization server metadata JSON object map.
+     *
+     * @param authorizationServerMetadataObject the JSON object map representing authorization server metadata
+     * @return EntityMetadataInfoClaimBuilder instance for method chaining
+     */
     public EntityMetadataInfoClaimBuilder authorizationServerMetadataObject(
         final Map<String, Object> authorizationServerMetadataObject) {
       this.entityMetadataInfoClaim.setAuthorizationServerMetadataObject(authorizationServerMetadataObject);
       return this;
     }
 
+    /**
+     * Sets the OAuth client metadata JSON object map.
+     *
+     * @param oauthClientMetadataObject A JSON object map representing the OAuth client metadata
+     * @return EntityMetadataInfoClaimBuilder instance for method chaining
+     */
     public EntityMetadataInfoClaimBuilder oauthClientMetadataObject(
         final Map<String, Object> oauthClientMetadataObject) {
       this.entityMetadataInfoClaim.setOauthClientMetadataObject(oauthClientMetadataObject);
       return this;
     }
 
+    /**
+     * Sets the OAuth resource metadata JSON object map.
+     *
+     * @param oauthResourceMetadataObject a JSON object map representing OAuth resource metadata
+     * @return EntityMetadataInfoClaimBuilder instance for method chaining
+     */
     public EntityMetadataInfoClaimBuilder oauthResourceMetadataObject(
         final Map<String, Object> oauthResourceMetadataObject) {
       this.entityMetadataInfoClaim.setOauthResourceMetadataObject(oauthResourceMetadataObject);
       return this;
     }
 
+    /**
+     * Sets the Federation Entity metadata JSON object map
+     *
+     * @param federationEntityMetadataObject a JSON object map representing Federation Entity metadata
+     * @return EntityMetadataInfoClaimBuilder instance for method chaining
+     */
     public EntityMetadataInfoClaimBuilder federationEntityMetadataObject(
         final Map<String, Object> federationEntityMetadataObject) {
       this.entityMetadataInfoClaim.setFederationEntityMetadataObject(federationEntityMetadataObject);
       return this;
     }
 
+    /**
+     * Sets a custom entity metadata object for a specific metadata type.
+     *
+     * @param metadataTypeName the type of metadata for which to set the custom entity metadata
+     * @param entityMetadataObject a SON object map representing the custom entity metadata
+     * @return an EntityMetadataInfoClaimBuilder instance for method chaining
+     */
     public EntityMetadataInfoClaimBuilder customEntityMetadataObject(String metadataTypeName, Map<String, Object> entityMetadataObject) {
       this.entityMetadataInfoClaim.setMetadataClaimsObject(metadataTypeName, entityMetadataObject);
       return this;
     }
 
+    /**
+     * Builds and returns the EntityMetadataInfoClaim object that has been constructed so far.
+     *
+     * @return The EntityMetadataInfoClaim object representing the constructed entity metadata information.
+     */
     public EntityMetadataInfoClaim build() {
       return this.entityMetadataInfoClaim;
     }
 
   }
 
-
+  /**
+   * Custom serializer for EntityMetadataInfoClaim objects.
+   * This class extends the JsonSerializer class to handle serialization of EntityMetadataInfoClaim objects.
+   * It overrides the serialize method to write the claimObjects property of the EntityMetadataInfoClaim object to the JsonGenerator.
+   */
   public static class EntityMetadataInfoClaimSerializer extends JsonSerializer<EntityMetadataInfoClaim> {
 
+    /**
+     * Serializes the EntityMetadataInfoClaim object to JSON.
+     *
+     * @param value the EntityMetadataInfoClaim object to be serialized
+     * @param gen the JsonGenerator used to write the JSON content
+     * @param serializers the SerializerProvider for serialization
+     * @throws IOException If an I/O error occurs while writing the JSON.
+     */
     @Override
     public void serialize(EntityMetadataInfoClaim value, JsonGenerator gen, SerializerProvider serializers)
       throws IOException {
@@ -183,8 +327,21 @@ public class EntityMetadataInfoClaim {
     }
   }
 
+  /**
+   * Custom JSON deserializer for EntityMetadataInfoClaim objects.
+   * This class extends JsonDeserializer and defines the deserialize method to convert JSON data
+   * into an EntityMetadataInfoClaim object.
+   */
   public static class EntityMetadataInfoClaimDeserializer extends JsonDeserializer<EntityMetadataInfoClaim> {
 
+    /**
+     * Deserialize a JSON content into an EntityMetadataInfoClaim object.
+     *
+     * @param p JsonParser used to read JSON content.
+     * @param ctxt DeserializationContext for deserialization configuration.
+     * @return An EntityMetadataInfoClaim object populated with data from the JSON content.
+     * @throws IOException if an I/O error occurs during deserialization.
+     */
     @Override
     public EntityMetadataInfoClaim deserialize(JsonParser p, DeserializationContext ctxt)
       throws IOException {

--- a/src/main/java/se/oidc/oidfed/base/data/federation/EntityMetadataInfoClaim.java
+++ b/src/main/java/se/oidc/oidfed/base/data/federation/EntityMetadataInfoClaim.java
@@ -15,17 +15,31 @@
  */
 package se.oidc.oidfed.base.data.federation;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Data;
+import lombok.Getter;
 
+import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
  * Metadata claims data for both the metadata claim and the metadata_policy claim
  */
-@Data
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@Getter
+@JsonSerialize(using = EntityMetadataInfoClaim.EntityMetadataInfoClaimSerializer.class)
+@JsonDeserialize(using = EntityMetadataInfoClaim.EntityMetadataInfoClaimDeserializer.class)
 public class EntityMetadataInfoClaim {
 
   public static final String OPENID_RELYING_PARTY = "openid_relying_party";
@@ -41,6 +55,7 @@ public class EntityMetadataInfoClaim {
    * Constructor for the EntityMetadataInfoClaim class.
    */
   protected EntityMetadataInfoClaim() {
+    claimObjects = new HashMap<>();
   }
 
   /*
@@ -64,8 +79,7 @@ public class EntityMetadataInfoClaim {
   public void setOidcRelyingPartyMetadataObject(Map<String, Object> oidcRelyingPartyMetadata){
     this.claimObjects.put(OPENID_RELYING_PARTY, oidcRelyingPartyMetadata);
 
-  @JsonProperty("oauth_authorization_server")
-  protected Map<String, Object> authorizationServerMetadataObject;
+  }
 
   /**
    * Retrieves the OpenID Connect Provider metadata as a JSON object map.
@@ -205,7 +219,7 @@ public class EntityMetadataInfoClaim {
      */
     public EntityMetadataInfoClaimBuilder oidcRelyingPartyMetadataObject(
         final Map<String, Object> oidcRelyingPartyMetadataObject) {
-      this.entityMetadataInfoClaim.oidcRelyingPartyMetadataObject = oidcRelyingPartyMetadataObject;
+      this.entityMetadataInfoClaim.setOidcRelyingPartyMetadataObject(oidcRelyingPartyMetadataObject);
       return this;
     }
 
@@ -216,7 +230,7 @@ public class EntityMetadataInfoClaim {
      * @return EntityMetadataInfoClaimBuilder instance for method chaining
      */
     public EntityMetadataInfoClaimBuilder opMetadataObject(final Map<String, Object> opMetadataObject) {
-      this.entityMetadataInfoClaim.opMetadataObject = opMetadataObject;
+      this.entityMetadataInfoClaim.setOpMetadataObject(opMetadataObject);
       return this;
     }
 
@@ -228,7 +242,7 @@ public class EntityMetadataInfoClaim {
      */
     public EntityMetadataInfoClaimBuilder authorizationServerMetadataObject(
         final Map<String, Object> authorizationServerMetadataObject) {
-      this.entityMetadataInfoClaim.authorizationServerMetadataObject = authorizationServerMetadataObject;
+      this.entityMetadataInfoClaim.setAuthorizationServerMetadataObject(authorizationServerMetadataObject);
       return this;
     }
 
@@ -240,7 +254,7 @@ public class EntityMetadataInfoClaim {
      */
     public EntityMetadataInfoClaimBuilder oauthClientMetadataObject(
         final Map<String, Object> oauthClientMetadataObject) {
-      this.entityMetadataInfoClaim.oauthClientMetadataObject = oauthClientMetadataObject;
+      this.entityMetadataInfoClaim.setOauthClientMetadataObject(oauthClientMetadataObject);
       return this;
     }
 
@@ -252,7 +266,7 @@ public class EntityMetadataInfoClaim {
      */
     public EntityMetadataInfoClaimBuilder oauthResourceMetadataObject(
         final Map<String, Object> oauthResourceMetadataObject) {
-      this.entityMetadataInfoClaim.oauthResourceMetadataObject = oauthResourceMetadataObject;
+      this.entityMetadataInfoClaim.setOauthResourceMetadataObject(oauthResourceMetadataObject);
       return this;
     }
 

--- a/src/main/java/se/oidc/oidfed/base/process/chain/impl/DefaultFederationChainValidator.java
+++ b/src/main/java/se/oidc/oidfed/base/process/chain/impl/DefaultFederationChainValidator.java
@@ -260,7 +260,7 @@ public class DefaultFederationChainValidator implements FederationChainValidator
       return OidcUtils.readJsonObject(metadataJsonObject, EntityMetadataInfoClaim.class);
 
     }
-    catch (final PolicyTranslationException | PolicyProcessingException | JsonProcessingException e) {
+    catch (final PolicyTranslationException | PolicyProcessingException e) {
       throw new ChainValidationException("Failed to process metadata against policy", e);
     }
 
@@ -339,14 +339,7 @@ public class DefaultFederationChainValidator implements FederationChainValidator
       }
       collectedMetadataObject.put(entityType, collectedMetadataParams);
     }
-
-    try {
-      return OidcUtils.readJsonObject(collectedMetadataObject, EntityMetadataInfoClaim.class);
-    }
-    catch (final JsonProcessingException e) {
-      throw new ChainValidationException("Illegal collected metadata", e);
-    }
-
+    return OidcUtils.readJsonObject(collectedMetadataObject, EntityMetadataInfoClaim.class);
   }
 
   private List<String> getAllKeys(Map<String, ?> firstMap, Map<String, ?> secondMap) {

--- a/src/main/java/se/oidc/oidfed/base/utils/OidcUtils.java
+++ b/src/main/java/se/oidc/oidfed/base/utils/OidcUtils.java
@@ -44,10 +44,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * OIDC Utils.
- *
- * @author Martin Lindström (martin@idsec.se)
- * @author Stefan Santesson (stefan@idsec.se)
+ * OID federation Utilities.
  */
 public class OidcUtils {
 
@@ -70,7 +67,7 @@ public class OidcUtils {
    *
    * @param dataObject Data object containing parameters that are not part of the extension set
    * @param payload payload of the JWT from which the extension claims are collected
-   * @return json object map containing the extension claims
+   * @return JSON object map containing the extension claims
    * @throws JsonProcessingException JSON processing errors
    */
   public static Map<String, Object> getExtensionProperties(final Map<String, Object> payload, Object dataObject)
@@ -217,6 +214,14 @@ public class OidcUtils {
     }
   }
 
+  /**
+   * Verifies the type of a given value based on the specified value type.
+   *
+   * @param value the value to verify
+   * @param valueType the type of value expected
+   * @return the verified value as a String
+   * @throws PolicyTranslationException if the type verification fails or is unsupported
+   */
   public static String verifyValueType(final Object value, final String valueType) throws PolicyTranslationException {
     switch (valueType) {
     case ValueType.STRING:
@@ -257,6 +262,14 @@ public class OidcUtils {
     }
   }
 
+  /**
+   * Converts a List of strings to an object based on the specified value type.
+   *
+   * @param value the List of strings to convert
+   * @param valueType the type of object to convert to
+   * @return the converted object
+   * @throws PolicyTranslationException if an error occurs during conversion
+   */
   public static Object convertToValueObject(final List<String> value, final String valueType)
       throws PolicyTranslationException {
 
@@ -309,6 +322,13 @@ public class OidcUtils {
     }
   }
 
+  /**
+   * Retrieves a JWS verifier based on the provided JWK key. Supports EC and RSA keys.
+   *
+   * @param jwk the JWK key to obtain a JWS verifier for
+   * @return a JWS verifier for the provided JWK key
+   * @throws JOSEException if an unsupported key type is encountered
+   */
   public static JWSVerifier getVerifier(final JWK jwk) throws JOSEException {
 
     final KeyType keyType = jwk.getKeyType();
@@ -321,6 +341,14 @@ public class OidcUtils {
     throw new JOSEException("Unsupported key type");
   }
 
+  /**
+   * Verify the signed JWT using a JWK set.
+   *
+   * @param signedJWT the SignedJWT to verify
+   * @param jwkSet the JWKSet containing keys for verification
+   * @return true if the JWT signature is valid with any of the keys in the JWK set, false otherwise
+   * @throws JOSEException if an unsupported key type is encountered during verification
+   */
   public static boolean verifySignedJWT(final SignedJWT signedJWT, final JWKSet jwkSet) throws JOSEException {
 
     for (final JWK jwk : jwkSet.getKeys()) {
@@ -331,10 +359,27 @@ public class OidcUtils {
     return false;
   }
 
+  /**
+   * Verify the validity time of a SignedJWT by checking the issue time and expiration time against the current time.
+   * Throws a ParseException if parsing fails and JOSEException if any validation check fails.
+   *
+   * @param signedJWT the SignedJWT to verify
+   * @throws ParseException if parsing fails
+   * @throws JOSEException if validation checks fail
+   */
   public static void verifyValidityTime(final SignedJWT signedJWT) throws ParseException, JOSEException {
     verifyValidityTime(signedJWT, 15);
   }
 
+  /**
+   * Verify the validity time of a SignedJWT by checking the issue time and expiration time against the current time allowing time skew.
+   * Throws a ParseException if parsing fails and JOSEException if any validation check fails.
+   *
+   * @param signedJWT the SignedJWT to verify
+   * @param timeSkew the time skew in seconds to allow for time differences
+   * @throws ParseException if parsing fails
+   * @throws JOSEException if any validation check fails
+   */
   public static void verifyValidityTime(final SignedJWT signedJWT, final int timeSkew)
       throws ParseException, JOSEException {
 
@@ -359,20 +404,25 @@ public class OidcUtils {
     }
   }
 
+  /**
+   * Converts any object to a JSON object map
+   *
+   * @param object the object to convert to a JSON object map
+   * @return JSON object map
+   */
   public static Map<String, Object> toJsonObject(final Object object) {
-    try {
-      return OBJECT_MAPPER.readValue(OBJECT_MAPPER.writeValueAsString(object), new TypeReference<>() {
-      });
-    }
-    catch (final JsonProcessingException e) {
-      throw new RuntimeException(e);
-    }
-
+    return OBJECT_MAPPER.convertValue(object, new TypeReference<>() {});
   }
 
-  public static <T> T readJsonObject(final Map<String, Object> jsonObject, final Class<T> targetClassType)
-      throws JsonProcessingException {
-    return OBJECT_MAPPER.readValue(OBJECT_MAPPER.writeValueAsString(jsonObject), targetClassType);
+  /**
+   * Converts a JSON object map to a target class
+   *
+   * @param jsonObject JSON object map
+   * @param targetClassType target class type
+   * @return object as an instance of the targetClassType
+   * @param <T> target class
+   */
+  public static <T> T readJsonObject(final Map<String, Object> jsonObject, final Class<T> targetClassType) {
+    return OBJECT_MAPPER.convertValue(jsonObject, targetClassType);
   }
-
 }


### PR DESCRIPTION
This issue fix a limitation in EntityMetadataInfoClaim so that any type of metadata can be stored.

Updated to release version 2.0.1